### PR TITLE
#158 Fix schematron rule per temporalExtent

### DIFF
--- a/src/main/plugin/iso19139.rndt/schematron/schematron-rules-rndt.sch
+++ b/src/main/plugin/iso19139.rndt/schematron/schematron-rules-rndt.sch
@@ -602,9 +602,8 @@ temporalSamplingService;temporalProximityAnalysisService;metadataProcessingServi
 		<sch:title>$loc/strings/M200</sch:title>
 		<sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/*:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent[//gml:TimePeriod]">
 
-			<sch:let name="testBegin" value="count(gml:TimePeriod//gml:beginPosition[text() != '' or @indeterminatePosition != ''])>0"/>
-      <sch:let name="testEnd"   value="count(gml:TimePeriod//gml:endPosition[text() != '' or @indeterminatePosition != ''])>0"/>
-
+			<sch:let name="testBegin" value="count(gml:TimePeriod//gml:beginPosition[text() != '' or @indeterminatePosition != ''])>0 and count(gml:TimePeriod//gml:beginPosition[text() = '' and @indeterminatePosition == 'before'])=0"/>
+      <sch:let name="testEnd"   value="count(gml:TimePeriod//gml:endPosition[text() != '' or @indeterminatePosition != ''])>0 and count(gml:TimePeriod//gml:endPosition[text() = '' and @indeterminatePosition == 'after'])=0"/>
 			<sch:assert test="$testBegin">$loc/strings/alert.M201</sch:assert>
 			<sch:assert test="$testEnd">$loc/strings/alert.M202</sch:assert>
 

--- a/src/main/plugin/iso19139.rndt/schematron/schematron-rules-rndt.sch
+++ b/src/main/plugin/iso19139.rndt/schematron/schematron-rules-rndt.sch
@@ -600,14 +600,13 @@ temporalSamplingService;temporalProximityAnalysisService;metadataProcessingServi
     <!--ESTENSIONE TEMPORALE-->
 	<sch:pattern>
 		<sch:title>$loc/strings/M200</sch:title>
-		<sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent[//gml:TimePeriod]
-                                  |//gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/srv:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent[//gml:TimePeriod]">
+		<sch:rule context="//gmd:MD_Metadata/gmd:identificationInfo/*/*:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent[//gml:TimePeriod]">
 
-			<sch:let name="beginPosition" value="gml:TimePeriod//gml:beginPosition/text()"/>
-			<sch:let name="endPosition"   value="gml:TimePeriod//gml:endPosition/text()"/>
+			<sch:let name="testBegin" value="count(gml:TimePeriod//gml:beginPosition[text() != '' or @indeterminatePosition != ''])>0"/>
+      <sch:let name="testEnd"   value="count(gml:TimePeriod//gml:endPosition[text() != '' or @indeterminatePosition != ''])>0"/>
 
-			<sch:assert test="$beginPosition != ''">$loc/strings/alert.M201</sch:assert>
-			<sch:assert test="$endPosition   != ''">$loc/strings/alert.M202</sch:assert>
+			<sch:assert test="$testBegin">$loc/strings/alert.M201</sch:assert>
+			<sch:assert test="$testEnd">$loc/strings/alert.M202</sch:assert>
 
 		</sch:rule>
 	</sch:pattern>


### PR DESCRIPTION
fix regola schematron per temporalExtent: la validazione deve passare anche se i soli attributi indeterminatePosition sono valorizzati