### PR TITLE
#165 Alcuni asterischi obbligatorietà mancano

### DIFF
--- a/src/main/plugin/iso19139.rndt/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.rndt/layout/config-editor.xml
@@ -1549,7 +1549,7 @@
 
           <section name="topicCategory">
           <field
-            xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:topicCategory/gmd:MD_TopicCategoryCode"
+            xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:topicCategory"
             if="count(gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification) > 0"/>
           <action type="add"
                   btnLabel="addTopic"

--- a/src/main/plugin/iso19139.rndt/layout/layout-custom-fields.xsl
+++ b/src/main/plugin/iso19139.rndt/layout/layout-custom-fields.xsl
@@ -79,6 +79,7 @@
             <xsl:with-param name="schema" select="$schema"/>
             <xsl:with-param name="labels" select="$labels"/>
             <xsl:with-param name="lang" select="'it'"/>
+            <xsl:with-param name="isRequired" select="true()"/>
           </xsl:call-template>
         </xsl:if>
       <xsl:if test="./name()='gmd:otherConstraints' and boolean(./gmx:Anchor) and boolean(../gmd:useConstraints)">
@@ -90,6 +91,7 @@
           <xsl:with-param name="schema" select="$schema"/>
           <xsl:with-param name="labels" select="$labels"/>
           <xsl:with-param name="lang" select="'it'"/>
+          <xsl:with-param name="isRequired" select="true()"/>
         </xsl:call-template>
       </xsl:if>
     </xsl:for-each>

--- a/src/main/plugin/iso19139.rndt/schema/gmd/citation.xsd
+++ b/src/main/plugin/iso19139.rndt/schema/gmd/citation.xsd
@@ -51,7 +51,7 @@
 					<xs:element name="edition" type="gco:CharacterString_PropertyType" minOccurs="0"/>
 					<xs:element name="editionDate" type="gco:Date_PropertyType" minOccurs="0"/>
 					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="citedResponsibleParty" type="gmd:CI_ResponsibleParty_PropertyType" minOccurs="1" maxOccurs="unbounded"/>
+					<xs:element name="citedResponsibleParty" type="gmd:CI_ResponsibleParty_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="presentationForm" type="gmd:CI_PresentationFormCode_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="series" type="gmd:CI_Series_PropertyType" minOccurs="0"/>
 					<xs:element name="otherCitationDetails" type="gco:CharacterString_PropertyType" minOccurs="0"/>

--- a/src/main/plugin/iso19139.rndt/schema/gmd/citation.xsd
+++ b/src/main/plugin/iso19139.rndt/schema/gmd/citation.xsd
@@ -51,7 +51,7 @@
 					<xs:element name="edition" type="gco:CharacterString_PropertyType" minOccurs="0"/>
 					<xs:element name="editionDate" type="gco:Date_PropertyType" minOccurs="0"/>
 					<xs:element name="identifier" type="gmd:MD_Identifier_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
-					<xs:element name="citedResponsibleParty" type="gmd:CI_ResponsibleParty_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
+					<xs:element name="citedResponsibleParty" type="gmd:CI_ResponsibleParty_PropertyType" minOccurs="1" maxOccurs="unbounded"/>
 					<xs:element name="presentationForm" type="gmd:CI_PresentationFormCode_PropertyType" minOccurs="0" maxOccurs="unbounded"/>
 					<xs:element name="series" type="gmd:CI_Series_PropertyType" minOccurs="0"/>
 					<xs:element name="otherCitationDetails" type="gco:CharacterString_PropertyType" minOccurs="0"/>

--- a/src/main/plugin/iso19139.rndt/schematron/schematron-rules-rndt.sch
+++ b/src/main/plugin/iso19139.rndt/schematron/schematron-rules-rndt.sch
@@ -443,13 +443,13 @@ temporalSamplingService;temporalProximityAnalysisService;metadataProcessingServi
 			//gmd:MD_Metadata/gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints">
 
 			<sch:assert test="count(gmd:MD_LegalConstraints[
-                                gmd:otherConstraints/gco:CharacterString != ''
+                                gmd:otherConstraints/gmx:Anchor != ''
                             and gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue!='otherRestrictions'
                             and gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue!='otherRestrictions'])=0">$loc/strings/alert.M53notneeded</sch:assert>
 
 			<sch:assert test="count(gmd:MD_LegalConstraints[
-                                /gmd:otherConstraints/gco:CharacterString = ''
-                            and (   gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue='otherRestrictions'
+                                /gmd:otherConstraints/gmx:Anchor = ''
+                            and (gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue='otherRestrictions'
 				                 or gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue='otherRestrictions')]) = 0">$loc/strings/alert.M53missing</sch:assert>
 
 		</sch:rule>


### PR DESCRIPTION
- aggiunge * per otherConstraints dal layout-custom-fields.xsl. Fix rule schematron;

- utilizzo thesauro per topicCategory, che mostra l'asterisco di obbligatorietà. Le categorie vengono listate tutte se lo user non digita niente.

- per campo responsabile e estensione ci sono rule schematron