### PR TITLE
Associazione Risorsa accoppiata

### DIFF
--- a/src/main/plugin/iso19139.rndt/process/add-info-from-wms.xsl
+++ b/src/main/plugin/iso19139.rndt/process/add-info-from-wms.xsl
@@ -1,4 +1,399 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="../../iso19139/process/add-info-from-wms.xsl"/>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common" xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:math="http://exslt.org/math"
+                version="2.0"
+                exclude-result-prefixes="srv gco gmd exslt geonet math">
+
+  <xsl:import href="process-utility.xsl"/>
+
+  <!-- i18n information -->
+  <xsl:variable name="wms-info-loc">
+    <msg id="a" xml:lang="eng">WMS service </msg>
+    <msg id="b" xml:lang="eng">is described in online resource section. Run to update extent, CRS or
+      graphic overview
+      for this WMS service for the layer named:
+    </msg>
+    <msg id="a" xml:lang="fre">Le service de visualisation</msg>
+    <msg id="b" xml:lang="fre">est décrit dans la section resource en ligne. Exécuter cette action
+      pour mettre à jour l'étendue, les systèmes de projection
+      ou les aperçus pour ce service et la couche nommée :
+    </msg>
+    <msg id="a" xml:lang="dut">Er is een verwijzing gevonden naar de WMS service </msg>
+    <msg id="b" xml:lang="dut">. Gebruik deze functie om de dekking, de projectie of thumbnail af te leiden of bij te werken vanuit deze WMS-service voor de laag met de naam: </msg>
+    <msg id="a" xml:lang="ita">Un servizio WMS</msg>
+    <msg id="b" xml:lang="ita">è definito nella sezione di risorse online.
+        Lancia questo processo per aggiornare l'estensione, il CRS o l'anteprima di questo servizio WMS
+        con il layer di nome:
+    </msg>
+  </xsl:variable>
+
+  <!-- Process parameters and variables-->
+  <xsl:param name="mode" select="'process'"/>
+  <xsl:param name="setExtent" select="'0'"/>
+  <xsl:param name="setAndReplaceExtent" select="'0'"/>
+  <xsl:param name="setCRS" select="'0'"/>
+  <xsl:param name="setDynamicGraphicOverview" select="'0'"/>
+  <xsl:param name="wmsServiceUrl"/>
+
+  <xsl:variable name="setExtentMode" select="geonet:parseBoolean($setExtent)"/>
+  <xsl:variable name="setAndReplaceExtentMode" select="geonet:parseBoolean($setAndReplaceExtent)"/>
+  <xsl:variable name="setCRSMode" select="geonet:parseBoolean($setCRS)"/>
+  <xsl:variable name="setDynamicGraphicOverviewMode"
+                select="geonet:parseBoolean($setDynamicGraphicOverview)"/>
+
+
+  <!-- Load the capabilities document if one oneline resource contains a protocol set to WMS
+  -->
+  <xsl:variable name="onlineNodes"
+                select="//gmd:CI_OnlineResource[contains(gmd:protocol/gmx:Anchor/@xlink:href, 'wms') and normalize-space(gmd:linkage/gmd:URL)=$wmsServiceUrl]"/>
+  <xsl:variable name="layerName" select="$onlineNodes/gmd:name/gco:CharacterString"/>
+  <xsl:variable name="capabilitiesDoc">
+    <xsl:if test="$onlineNodes">
+      <xsl:copy-of select="geonet:get-wms-capabilities($wmsServiceUrl, '1.1.1')"/>
+    </xsl:if>
+  </xsl:variable>
+
+
+  <xsl:template name="list-add-info-from-wms">
+    <suggestion process="add-info-from-wms"/>
+  </xsl:template>
+
+
+  <!-- Analyze the metadata record and return available suggestion
+    for that process -->
+  <xsl:template name="analyze-add-info-from-wms">
+    <xsl:param name="root"/>
+
+    <xsl:variable name="onlineResources"
+                  select="$root//gmd:onLine/gmd:CI_OnlineResource[contains(gmd:protocol/gmx:Anchor/@xlink:href, 'wms')
+                                            and normalize-space(gmd:linkage/gmd:URL)!='']"/>
+    <xsl:variable name="srv"
+                  select="$root//*[local-name(.)='SV_ServiceIdentification' or contains(@gco:isoType, 'SV_ServiceIdentification')]"/>
+
+    <!-- Check if server is up and new value are available
+     <xsl:variable name="capabilities"
+      select="geonet:get-wms-capabilities(gmd:linkage/gmd:URL, '1.1.1')"/>
+-->
+    <xsl:for-each select="$onlineResources">
+      <suggestion process="add-info-from-wms" id="{generate-id()}" category="onlineSrc"
+                  target="gmd:extent">
+        <name>
+          <xsl:value-of select="geonet:i18n($wms-info-loc, 'a', $guiLang)"/><xsl:value-of
+          select="./gmd:linkage/gmd:URL"
+        /><xsl:value-of select="geonet:i18n($wms-info-loc, 'b', $guiLang)"/><xsl:value-of
+          select="./gmd:name/gco:CharacterString"/>.
+        </name>
+        <operational>true</operational>
+        <params>{"setExtent":{"type":"boolean", "defaultValue":"<xsl:value-of select="$setExtent"/>"},
+          "setAndReplaceExtent":{"type":"boolean", "defaultValue":"<xsl:value-of
+            select="$setAndReplaceExtent"/>"}, "setCRS":{"type":"boolean", "defaultValue":"<xsl:value-of
+            select="$setCRS"/>"},
+          <xsl:if test="not($srv)">
+            "setDynamicGraphicOverview":{"type":"boolean",
+            "defaultValue":"<xsl:value-of select="$setDynamicGraphicOverview"/>"},
+          </xsl:if>
+          "wmsServiceUrl":{"type":"string", "defaultValue":"<xsl:value-of
+            select="normalize-space(gmd:linkage/gmd:URL)"/>"}
+          }
+        </params>
+      </suggestion>
+    </xsl:for-each>
+
+  </xsl:template>
+
+
+  <!-- Processing templates -->
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+
+  <!-- Here set extent and graphicOverview -->
+  <xsl:template
+    match="gmd:identificationInfo/*"
+    priority="2">
+
+    <xsl:variable name="srv"
+                  select="local-name(.)='SV_ServiceIdentification'
+            or contains(@gco:isoType, 'SV_ServiceIdentification')"/>
+
+
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <!-- Copy all elements from AbstractMD_IdentificationType-->
+      <xsl:copy-of
+        select="gmd:citation|
+        gmd:abstract|
+        gmd:purpose|
+        gmd:credit|
+        gmd:status|
+        gmd:pointOfContact|
+        gmd:resourceMaintenance|
+        gmd:graphicOverview
+        "/>
+      <!-- graphic overview-->
+      <xsl:if test="$setDynamicGraphicOverviewMode and $wmsServiceUrl!='' and $layerName!=''">
+        <xsl:variable name="wmsBbox"
+                      select="$capabilitiesDoc//Layer[Name=$layerName]/LatLonBoundingBox"/>
+        <xsl:if test="$wmsBbox/@minx!=''">
+          <gmd:graphicOverview>
+            <gmd:MD_BrowseGraphic>
+              <gmd:fileName>
+                <gco:CharacterString>
+
+                  <xsl:value-of
+                    select="geonet:get-wms-thumbnail-url($wmsServiceUrl, '1.1.1', $layerName,
+                                concat($wmsBbox/@minx, ',', $wmsBbox/@miny, ',', $wmsBbox/@maxx, ',', $wmsBbox/@maxy))"
+                  />
+                </gco:CharacterString>
+              </gmd:fileName>
+              <gmd:fileDescription>
+                <gco:CharacterString>
+                  <xsl:value-of select="$layerName"/>
+                </gco:CharacterString>
+              </gmd:fileDescription>
+            </gmd:MD_BrowseGraphic>
+          </gmd:graphicOverview>
+        </xsl:if>
+      </xsl:if>
+
+      <xsl:copy-of
+        select="gmd:resourceFormat|
+                gmd:descriptiveKeywords|
+                gmd:resourceSpecificUsage|
+                gmd:resourceConstraints|
+                gmd:aggregationInfo
+                "/>
+
+      <!-- Data -->
+      <xsl:copy-of
+        select="gmd:spatialRepresentationType|
+                gmd:spatialResolution|
+                gmd:language|
+                gmd:characterSet|
+                gmd:topicCategory|
+                gmd:environmentDescription
+                "/>
+
+      <!-- Service -->
+      <xsl:copy-of
+        select="srv:serviceType|
+                srv:serviceTypeVersion|
+                srv:accessProperties|
+                srv:restrictions|
+                srv:keywords
+                "/>
+
+      <!-- Keep existing extent and compute
+            from WMS service -->
+
+      <!-- replace or add extent. Default mode is add.
+            All extent element are processed and if a geographicElement is found,
+            it will be removed. Description, verticalElement and temporalElement
+            are preserved.
+
+            GeographicElement element having BoundingPolygon are preserved.
+      -->
+      <xsl:choose>
+        <xsl:when test="$setExtentMode">
+          <xsl:for-each select="srv:extent|gmd:extent">
+
+            <xsl:choose>
+              <xsl:when
+                test="gmd:EX_Extent/gmd:temporalElement or gmd:EX_Extent/gmd:verticalElement
+                or gmd:EX_Extent/gmd:geographicElement[gmd:EX_BoundingPolygon]">
+                <xsl:copy>
+                  <xsl:copy-of select="gmd:EX_Extent"/>
+                </xsl:copy>
+              </xsl:when>
+              <xsl:when test="$setAndReplaceExtentMode"/>
+              <xsl:otherwise>
+                <xsl:copy>
+                  <xsl:copy-of select="gmd:EX_Extent"/>
+                </xsl:copy>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="srv:extent|gmd:extent"/>
+        </xsl:otherwise>
+      </xsl:choose>
+
+      <!-- New extent position is after existing ones. -->
+      <xsl:if test="$setExtentMode">
+        <xsl:for-each
+          select="//gmd:onLine/gmd:CI_OnlineResource[contains(gmd:protocol/gmx:Anchor/@xlink:href, 'wms') and gmd:linkage/gmd:URL=$wmsServiceUrl]">
+          <xsl:call-template name="add-extent-for-wms">
+            <xsl:with-param name="srv" select="$srv"/>
+          </xsl:call-template>
+        </xsl:for-each>
+      </xsl:if>
+
+      <!-- End of data -->
+      <xsl:copy-of select="gmd:supplementalInformation"/>
+
+      <!-- End of service -->
+      <xsl:copy-of select="srv:coupledResource|
+                srv:couplingType|
+                srv:containsOperations|
+                srv:operatesOn
+                "/>
+
+      <!-- Note: When applying this stylesheet
+            to an ISO profil having a new substitute for
+            MD_Identification, profil specific element copy.
+            -->
+      <xsl:for-each
+        select="*[namespace-uri()!='http://www.isotc211.org/2005/gmd'
+              and namespace-uri()!='http://www.isotc211.org/2005/srv']">
+        <xsl:copy-of select="."/>
+      </xsl:for-each>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <xsl:template match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
+    <xsl:copy>
+      <xsl:copy-of
+        select="gmd:fileIdentifier
+        |gmd:language
+        |gmd:characterSet
+        |gmd:parentIdentifier
+        |gmd:hierarchyLevel
+        |gmd:hierarchyLevelName
+        |gmd:contact
+        |gmd:dateStamp
+        |gmd:metadataStandardName
+        |gmd:metadataStandardVersion
+        |gmd:dataSetURI
+        |gmd:locale
+        |gmd:spatialRepresentationInfo
+        "/>
+
+      <!-- Set spatial ref-->
+      <xsl:if test="$setCRSMode and $capabilitiesDoc//SRS">
+        <xsl:for-each-group select="$capabilitiesDoc//SRS" group-by=".">
+          <gmd:referenceSystemInfo>
+            <gmd:MD_ReferenceSystem>
+              <xsl:call-template name="RefSystemTypes">
+                <xsl:with-param name="srs" select="current-grouping-key()"/>
+              </xsl:call-template>
+            </gmd:MD_ReferenceSystem>
+          </gmd:referenceSystemInfo>
+        </xsl:for-each-group>
+      </xsl:if>
+
+      <xsl:copy-of select="gmd:metadataExtensionInfo
+        "/>
+
+      <xsl:apply-templates select="gmd:identificationInfo"/>
+
+      <xsl:copy-of
+        select="gmd:contentInfo
+        |gmd:distributionInfo
+        |gmd:dataQualityInfo
+        |gmd:portrayalCatalogueInfo
+        |gmd:metadataConstraints
+        |gmd:applicationSchemaInfo
+        |gmd:metadataMaintenance
+        |gmd:series
+        |gmd:describes
+        |gmd:propertyType
+        |gmd:featureType
+        |gmd:featureAttribute
+        "/>
+
+
+      <xsl:for-each
+        select="*[namespace-uri()!='http://www.isotc211.org/2005/gmd' and namespace-uri()!='http://www.fao.org/geonetwork']">
+        <xsl:copy-of select="."/>
+      </xsl:for-each>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template name="RefSystemTypes">
+    <xsl:param name="srs"/>
+    <gmd:referenceSystemIdentifier>
+      <gmd:RS_Identifier>
+        <gmd:code>
+          <gco:CharacterString>
+            <xsl:value-of select="$srs"/>
+          </gco:CharacterString>
+        </gmd:code>
+      </gmd:RS_Identifier>
+    </gmd:referenceSystemIdentifier>
+  </xsl:template>
+
+
+  <!-- Utility templates -->
+  <xsl:template name="add-extent-for-wms">
+    <xsl:param name="srv" select="false()"/>
+    <xsl:param name="status" select="false()"/>
+
+    <xsl:variable name="layerName" select="gmd:name/gco:CharacterString/text()"/>
+
+    <xsl:choose>
+      <xsl:when test="$srv">
+        <xsl:variable name="minx" select="math:min($capabilitiesDoc//LatLonBoundingBox/@minx)"/>
+        <xsl:variable name="maxx" select="math:max($capabilitiesDoc//LatLonBoundingBox/@maxx)"/>
+        <xsl:variable name="miny" select="math:min($capabilitiesDoc//LatLonBoundingBox/@miny)"/>
+        <xsl:variable name="maxy" select="math:max($capabilitiesDoc//LatLonBoundingBox/@maxy)"/>
+        <srv:extent>
+          <xsl:copy-of
+            select="geonet:make-iso-extent(string($minx), string($miny), string($maxx), string($maxy), '')"/>
+        </srv:extent>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:apply-templates select="$capabilitiesDoc//Layer[Name=$layerName]"
+                             mode="create-bbox-for-wms"/>
+      </xsl:otherwise>
+    </xsl:choose>
+
+  </xsl:template>
+
+
+  <!-- Create a bounding box -->
+  <xsl:template mode="create-bbox-for-wms" match="Layer">
+    <xsl:param name="srv" select="false()"/>
+
+    <xsl:for-each select="LatLonBoundingBox">
+      <gmd:extent>
+        <xsl:copy-of select="geonet:make-iso-extent(@minx, @miny, @maxx, @maxy, '')"/>
+      </gmd:extent>
+    </xsl:for-each>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/add-service-info-from-wxs.xsl
+++ b/src/main/plugin/iso19139.rndt/process/add-service-info-from-wxs.xsl
@@ -1,4 +1,331 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="../../iso19139/process/add-service-info-from-wxs.xsl"/>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:exslt="http://exslt.org/common" xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:wfs="http://www.opengis.net/wfs"
+                xmlns:wcs="http://www.opengis.net/wcs"
+                xmlns:wms="http://www.opengis.net/wms"
+                xmlns:ows="http://www.opengis.net/ows"
+                xmlns:owsg="http://www.opengeospatial.net/ows"
+                xmlns:ows11="http://www.opengis.net/ows/1.1"
+                xmlns:wps="http://www.opengeospatial.net/wps"
+                xmlns:wps1="http://www.opengis.net/wps/1.0.0"
+                version="2.0"
+                exclude-result-prefixes="srv gco gmd exslt geonet wms wfs wcs ows owsg ows11 wps wps1 xlink">
+
+  <xsl:import href="process-utility.xsl"/>
+
+  <!-- i18n information -->
+  <xsl:variable name="wxs-info-loc">
+    <msg id="a" xml:lang="eng">OGC WMS or WFS service</msg>
+    <msg id="b" xml:lang="eng">is described in online resource section. Run this process to add
+      operations information
+    </msg>
+    <msg id="a" xml:lang="fre">Le service WMS ou WFS</msg>
+    <msg id="b" xml:lang="fre">est décrit dans la section resource en ligne. Exécuter cette action
+      pour ajouter ou remplacer les informations relatives aux opérations
+    </msg>
+    <msg id="a" xml:lang="dut">Er is een verwijzing gevonden naar de WMS of WFS service </msg>
+    <msg id="b" xml:lang="dut">. Voer deze functie uit om operationele informatie toe te voegen of bij te werken. </msg>
+    <msg id="a" xml:lang="ita">Un servizio OGC WMS o WFS</msg>
+    <msg id="b" xml:lang="ita">è descritto nella sezione delle risorse online.
+        Lancia questo processo per aggiungere le informazioni sulle operazioni disponibili.</msg>
+  </xsl:variable>
+
+  <!-- Process parameters and variables-->
+  <xsl:param name="setAndReplaceOperations" select="'0'"/>
+  <xsl:param name="wxsServiceUrl"/>
+
+  <xsl:variable name="setAndReplaceOperationsMode"
+                select="geonet:parseBoolean($setAndReplaceOperations)"/>
+
+
+  <!-- Load the capabilities document if one oneline resource contains a protocol set to WMS or WFS
+    Check if containsOperation element is already defined
+  -->
+  <xsl:variable name="wxsOnlineNodes"
+                select="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine//gmd:CI_OnlineResource[(contains(gmd:protocol/gco:CharacterString, 'OGC:WMS')
+    or contains(gmd:protocol/gco:CharacterString, 'OGC:WFS')) and gmd:linkage/gmd:URL = $wxsServiceUrl]"/>
+  <xsl:variable name="wxsProtocol" select="$wxsOnlineNodes/gmd:protocol/gmx:Anchor/text()"/>
+  <xsl:variable name="wxsProtocolLink" select="$wxsOnlineNodes/gmd:protocol/gmx:Anchor/@link:hreaf"/>
+  <xsl:variable name="wxsDesc" select="$wxsOnlineNodes/gmd:description/gmx:Anchor/text()"/>
+  <xsl:variable name="wxsDescLink" select="$wxsOnlineNodes/gmd:description/gmx:Anchor/@link:hreaf"/>
+
+  <xsl:variable name="alreadyContainsOp" select="count(//srv:containsOperations[
+      srv:SV_OperationMetadata/srv:connectPoint/gmd:CI_OnlineResource/gmd:linkage/gmd:URL=$wxsServiceUrl])"/>
+
+  <xsl:variable name="wxsCapabilitiesDoc">
+    <xsl:if test="$wxsOnlineNodes and $alreadyContainsOp = 0">
+      <xsl:choose>
+        <xsl:when test="contains($wxsProtocolLink, 'wms')">
+          <xsl:copy-of select="geonet:get-wxs-capabilities($wxsServiceUrl, 'WMS', '1.3.0')"/>
+        </xsl:when>
+        <xsl:when test="contains($wxsProtocol, 'wfs')">
+          <xsl:copy-of select="geonet:get-wxs-capabilities($wxsServiceUrl, 'WFS', '1.1.0')"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:message>process:add-service-info-from-wxs: Unsupported protocol.</xsl:message>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:variable>
+
+
+  <xsl:template name="list-add-service-info-from-wxs">
+    <suggestion process="add-service-info-from-wxs"/>
+  </xsl:template>
+
+
+  <!-- Analyze the metadata record and return available suggestion
+    for that process -->
+  <xsl:template name="analyze-add-service-info-from-wxs">
+    <xsl:param name="root"/>
+
+    <xsl:variable name="srv"
+                  select="$root//*[local-name(.)='SV_ServiceIdentification' or contains(@gco:isoType, 'SV_ServiceIdentification')]"/>
+
+    <xsl:variable name="onlineResources"
+                  select="$root//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource[(contains(gmd:protocol/gmx:Anchor/@xlink:href, 'wfs')
+                                            or contains(gmd:protocol/gmx:Anchor/@xlink:href, 'wfs'))
+                                            and normalize-space(gmd:linkage/gmd:URL)!='']"/>
+
+    <xsl:if test="$srv"><!-- Only apply to service metadata-->
+      <xsl:for-each select="$onlineResources">
+        <suggestion process="add-service-info-from-wxs" id="{generate-id()}-service"
+                    category="onlineSrc" target="srv:containsOperations">
+          <name>
+            <xsl:value-of select="geonet:i18n($wxs-info-loc, 'a', $guiLang)"/><xsl:value-of
+            select="./gmd:linkage/gmd:URL"
+          /><xsl:value-of select="geonet:i18n($wxs-info-loc, 'b', $guiLang)"/>.
+          </name>
+          <operational>true</operational>
+          <params>{ "setAndReplaceOperations":{"type":"boolean", "defaultValue":"<xsl:value-of
+            select="$setAndReplaceOperations"/>"},
+            "wxsServiceUrl":{"type":"string", "defaultValue":"<xsl:value-of
+              select="normalize-space(gmd:linkage/gmd:URL)"/>"}
+            }
+          </params>
+        </suggestion>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:template>
+
+
+  <!-- Processing templates -->
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+
+  <!-- Here set extent and graphicOverview -->
+  <xsl:template
+    match="gmd:identificationInfo/*"
+    priority="2">
+
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <!-- Copy all elements from AbstractMD_IdentificationType-->
+      <xsl:copy-of
+        select="gmd:*"/>
+
+
+      <!-- Service -->
+      <xsl:copy-of
+        select="srv:serviceType|
+                srv:serviceTypeVersion|
+                srv:accessProperties|
+                srv:restrictions|
+                srv:keywords|
+                srv:extent|
+                srv:coupledResource|
+                srv:couplingType
+                "/>
+      <!-- Adding contains operation info -->
+      <xsl:if test="not($setAndReplaceOperationsMode)">
+        <xsl:copy-of select="srv:containsOperations"/>
+      </xsl:if>
+
+      <!-- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+        Operation could be OGC standard operation described in specification
+        OR a specific process in a WPS. In that case, each process are described
+        as one operation.
+
+      TODO : WPS not supported yet
+      -->
+
+      <xsl:variable name="ows">
+        <xsl:choose>
+          <xsl:when test="(local-name($wxsCapabilitiesDoc/.)='WFS_Capabilities' and namespace-uri($wxsCapabilitiesDoc/.)='http://www.opengis.net/wfs'
+            and $wxsCapabilitiesDoc/./@version='1.1.0')
+            or (local-name($wxsCapabilitiesDoc/.)='Capabilities' and namespace-uri($wxsCapabilitiesDoc/.)='http://www.opengeospatial.net/wps')
+            or (local-name($wxsCapabilitiesDoc/.)='Capabilities' and namespace-uri($wxsCapabilitiesDoc/.)='http://www.opengis.net/wps/1.0.0')">
+            true
+          </xsl:when>
+          <xsl:otherwise>false</xsl:otherwise>
+        </xsl:choose>
+      </xsl:variable>
+
+      <xsl:for-each select="$wxsCapabilitiesDoc//Request/*|
+        $wxsCapabilitiesDoc//wfs:Request/*|
+        $wxsCapabilitiesDoc//wms:Request/*|
+        $wxsCapabilitiesDoc//wcs:Request/*|
+        $wxsCapabilitiesDoc//ows:OperationsMetadata/ows:Operation|
+        $wxsCapabilitiesDoc//ows11:OperationsMetadata/ows:Operation|
+        $wxsCapabilitiesDoc//wps:ProcessOfferings/*|
+        $wxsCapabilitiesDoc//wps1:ProcessOfferings/*">
+        <!-- Some services provide information about ows:ExtendedCapabilities TODO ? -->
+
+        <srv:containsOperations>
+          <srv:SV_OperationMetadata>
+            <srv:operationName>
+              <gco:CharacterString>
+                <xsl:choose>
+                  <xsl:when test="name(.)='wps:Process'">WPS Process:
+                    <xsl:value-of select="ows:Title|ows11:Title"/>
+                  </xsl:when>
+                  <xsl:when test="$ows='true'">
+                    <xsl:value-of select="@name"/>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:value-of select="name(.)"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </gco:CharacterString>
+            </srv:operationName>
+            <!--  CHECKME : DCPType/SOAP ?
+            <xsl:for-each select="DCPType/HTTP/*|wfs:DCPType/wfs:HTTP/*|wms:DCPType/wms:HTTP/*|
+            wcs:DCPType/wcs:HTTP/*|ows:DCP/ows:HTTP/*|ows11:DCP/ows11:HTTP/*"> -->
+            <srv:DCP>
+              <srv:DCPList
+                codeList="http://www.isotc211.org/2005/iso19119/resources/Codelist/gmxCodelists.xml#DCPList"
+                codeListValue="WebServices"/>
+            </srv:DCP>
+            <!--</xsl:for-each>-->
+
+            <xsl:if test="name(.)='wps:Process' or name(.)='wps11:ProcessOfferings'">
+              <srv:operationDescription>
+                <gco:CharacterString>
+                  <xsl:value-of select="ows:Abstract|ows11:Title"/>
+                </gco:CharacterString>
+              </srv:operationDescription>
+              <srv:invocationName>
+                <gco:CharacterString>
+                  <xsl:value-of select="ows:Identifier|ows11:Identifier"/>
+                </gco:CharacterString>
+              </srv:invocationName>
+            </xsl:if>
+
+            <xsl:for-each
+              select="Format|wms:Format|ows:Parameter[@name='AcceptFormats' or @name='outputFormat']">
+              <srv:connectPoint>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>
+                      <xsl:choose>
+                        <xsl:when test="$ows='true'">
+                          <xsl:value-of
+                            select="..//ows:Get[1]/@xlink:href"/><!-- FIXME supposed at least one Get -->
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <xsl:value-of
+                            select="..//*[1]/OnlineResource/@xlink:href|..//*[1]/wms:OnlineResource/@xlink:href"/>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                    </gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gmx:Anchor xlink:href="{$wxsProtocolLink}">
+                      <xsl:value-of select="$wxsProtocol"/>
+                    </gmx:Anchor>
+                  </gmd:protocol>
+                  <gmd:description>
+                    <gmx:Anchor xlink:href="{$wxsDescLink}">
+                      <xsl:value-of select="$wxsDesc"/>
+                    </gmx:Anchor>
+                  </gmd:description>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode
+                      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_OnLineFunctionCode"
+                      codeListValue="information"/>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </srv:connectPoint>
+            </xsl:for-each>
+
+
+            <!-- Some Operations in WFS 1.0.0 have no ResultFormat no CI_OnlineResource created
+              WCS has no output format
+            -->
+            <xsl:for-each select="wfs:ResultFormat/*">
+              <srv:connectPoint>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>
+                      <xsl:value-of select="../..//wfs:Get[1]/@onlineResource"/>
+                    </gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>
+                      <xsl:value-of select="name(.)"/>
+                    </gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:function>
+                    <gmd:CI_OnLineFunctionCode
+                      codeList="./resources/codeList.xml#CI_OnLineFunctionCode"
+                      codeListValue="information"/>
+                  </gmd:function>
+                </gmd:CI_OnlineResource>
+              </srv:connectPoint>
+            </xsl:for-each>
+          </srv:SV_OperationMetadata>
+        </srv:containsOperations>
+      </xsl:for-each>
+
+      <!-- End of service -->
+      <xsl:copy-of select="srv:operatesOn"/>
+
+      <!-- Note: When applying this stylesheet
+            to an ISO profil having a new substitute for
+            MD_Identification, profil specific element copy.
+            -->
+      <xsl:for-each
+        select="*[namespace-uri()!='http://www.isotc211.org/2005/gmd'
+              and namespace-uri()!='http://www.isotc211.org/2005/srv']">
+        <xsl:copy-of select="."/>
+      </xsl:for-each>
+    </xsl:copy>
+  </xsl:template>
+
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/dataset-add.xsl
+++ b/src/main/plugin/iso19139.rndt/process/dataset-add.xsl
@@ -1,0 +1,281 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Stylesheet used to update metadata for a service and
+attached it to the metadata for data.
+-->
+<xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:param name="uuidref"/>
+  <xsl:param name="scopedName"/>
+  <xsl:param name="siteUrl"/>
+  <xsl:param name="protocol" select="'OGC Web Map Service'"/>
+  <xsl:param name="url"/>
+  <xsl:param name="desc"/>
+
+  <xsl:template match="/gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
+
+    <xsl:copy>
+      <xsl:copy-of select="@*"/>
+      <xsl:copy-of
+        select="gmd:fileIdentifier|
+                gmd:language|
+                gmd:characterSet|
+                gmd:parentIdentifier|
+                gmd:hierarchyLevel|
+                gmd:hierarchyLevelName|
+                gmd:contact|
+                gmd:dateStamp|
+                gmd:metadataStandardName|
+                gmd:metadataStandardVersion|
+                gmd:dataSetURI|
+                gmd:locale|
+                gmd:spatialRepresentationInfo|
+                gmd:referenceSystemInfo|
+                gmd:metadataExtensionInfo"/>
+
+      <!-- Check current metadata is a service metadata record
+            And add the link to the dataset -->
+      <xsl:choose>
+        <xsl:when
+          test="gmd:identificationInfo/srv:SV_ServiceIdentification|
+                gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']">
+          <gmd:identificationInfo>
+            <srv:SV_ServiceIdentification>
+              <xsl:copy-of
+                select="gmd:identificationInfo/*/gmd:citation|
+                        gmd:identificationInfo/*/gmd:abstract|
+                        gmd:identificationInfo/*/gmd:purpose|
+                        gmd:identificationInfo/*/gmd:credit|
+                        gmd:identificationInfo/*/gmd:statut|
+                        gmd:identificationInfo/*/gmd:pointOfContact|
+                        gmd:identificationInfo/*/gmd:resourceMaintenance|
+                        gmd:identificationInfo/*/gmd:graphicOverview|
+                        gmd:identificationInfo/*/gmd:resourceFormat|
+                        gmd:identificationInfo/*/gmd:descriptiveKeywords|
+                        gmd:identificationInfo/*/gmd:resourceSpecificUsage|
+                        gmd:identificationInfo/*/gmd:resourceConstraints|
+                        gmd:identificationInfo/*/gmd:aggregationInfo|
+                        gmd:identificationInfo/*/srv:serviceType|
+                        gmd:identificationInfo/*/srv:serviceTypeVersion|
+                        gmd:identificationInfo/*/srv:accessProperties|
+                        gmd:identificationInfo/*/srv:restrictions|
+                        gmd:identificationInfo/*/srv:keywords|
+                        gmd:identificationInfo/*/srv:extent"/>
+
+
+              <!-- Handle SV_CoupledResource -->
+              <xsl:variable name="coupledResource">
+                <xsl:if test="$scopedName != ''">
+                  <xsl:for-each select="tokenize($scopedName, ',')">
+                    <srv:coupledResource>
+                      <srv:SV_CoupledResource>
+                        <srv:operationName>
+                          <gco:CharacterString>GetCapabilities</gco:CharacterString>
+                        </srv:operationName>
+                        <srv:identifier>
+                          <gco:CharacterString>
+                            <xsl:value-of select="$uuidref"/>
+                          </gco:CharacterString>
+                        </srv:identifier>
+                        <gco:ScopedName>
+                          <xsl:value-of select="."/>
+                        </gco:ScopedName>
+                      </srv:SV_CoupledResource>
+                    </srv:coupledResource>
+                  </xsl:for-each>
+                </xsl:if>
+                <xsl:if test="not($scopedName)">
+                  <srv:coupledResource>
+                    <srv:SV_CoupledResource>
+                      <srv:operationName>
+                        <gco:CharacterString>GetCapabilities</gco:CharacterString>
+                      </srv:operationName>
+                      <srv:identifier>
+                        <gco:CharacterString>
+                          <xsl:value-of select="$uuidref"/>
+                        </gco:CharacterString>
+                      </srv:identifier>
+                    </srv:SV_CoupledResource>
+                  </srv:coupledResource>
+                </xsl:if>
+              </xsl:variable>
+
+              <xsl:choose>
+                <xsl:when
+                  test="gmd:identificationInfo/*/srv:coupledResource">
+                  <xsl:for-each
+                    select="gmd:identificationInfo/*/srv:coupledResource">
+                    <xsl:choose>
+                      <xsl:when
+                        test="srv:SV_CoupledResource/srv:identifier/gco:CharacterString!=$uuidref">
+                        <xsl:copy-of select="."/>
+                      </xsl:when>
+                    </xsl:choose>
+                    <xsl:if test="position()=last()">
+                      <xsl:copy-of select="$coupledResource"/>
+                    </xsl:if>
+                  </xsl:for-each>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:if test="$uuidref and $uuidref != ''">
+                    <xsl:copy-of select="$coupledResource"/>
+                  </xsl:if>
+                </xsl:otherwise>
+
+              </xsl:choose>
+
+
+              <xsl:copy-of
+                select="gmd:identificationInfo/*/srv:couplingType|
+                        gmd:identificationInfo/*/srv:containsOperations|
+                        gmd:identificationInfo/*/srv:operatesOn[@uuidref!=$uuidref]"/>
+
+              <!-- Handle operatesOn
+
+              // TODO : it looks like the dataset identifier and not the
+              // metadata UUID should be set in the operatesOn element of
+              // the service metadata record.
+              -->
+              <srv:operatesOn uuidref="{$uuidref}"
+                              xlink:href="{$siteUrl}csw?service=CSW&amp;request=GetRecordById&amp;version=2.0.2&amp;outputSchema=http://www.isotc211.org/2005/gmd&amp;elementSetName=full&amp;id={$uuidref}"/>
+
+              <xsl:apply-templates select="*[namespace-uri()!='http://www.isotc211.org/2005/gmd' and
+                                             namespace-uri()!='http://www.isotc211.org/2005/srv']"/>
+            </srv:SV_ServiceIdentification>
+          </gmd:identificationInfo>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- Probably a dataset metadata record -->
+          <xsl:copy-of select="gmd:identificationInfo"/>
+        </xsl:otherwise>
+      </xsl:choose>
+
+      <xsl:copy-of select="gmd:contentInfo"/>
+
+
+      <xsl:choose>
+        <xsl:when
+          test="gmd:identificationInfo/srv:SV_ServiceIdentification|
+                gmd:identificationInfo/*[@gco:isoType='srv:SV_ServiceIdentification']">
+          <xsl:copy-of select="gmd:distributionInfo"/>
+        </xsl:when>
+        <!-- In a dataset add a link in the distribution section -->
+        <xsl:otherwise>
+          <!-- TODO we could check if online resource already exists before adding information -->
+          <gmd:distributionInfo>
+            <gmd:MD_Distribution>
+              <xsl:copy-of
+                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"/>
+              <xsl:copy-of
+                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor"/>
+              <gmd:transferOptions>
+                <gmd:MD_DigitalTransferOptions>
+                  <xsl:copy-of
+                    select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:unitsOfDistribution"/>
+                  <xsl:copy-of
+                    select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:transferSize"/>
+                  <xsl:copy-of
+                    select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:onLine"/>
+                   <gmd:onLine>
+                      <gmd:CI_OnlineResource>
+                        <gmd:linkage>
+                          <gmd:URL>
+                            <xsl:value-of select="$url"/>
+                          </gmd:URL>
+                        </gmd:linkage>
+                        <gmd:protocol>
+                          <gmx:Anchor xlink:href="http://www.opengis.net/def/serviceType/ogc/wms">
+                            <xsl:value-of select="$protocol"/>
+                          </gmx:Anchor>
+                        </gmd:protocol>
+                        <gmd:name>
+                          <gco:CharacterString>
+                            <xsl:value-of select="if ($scopedName != '') then $scopedName else $uuidref "/>
+                          </gco:CharacterString>
+                        </gmd:name>
+                        <gmd:description>
+                          <gmx:Anchor xlink:href="">
+                          </gmx:Anchor>
+                        </gmd:description>
+                        <gmd:applicationProfile>
+                          <gmx:Anchor xlink:href="">
+                          </gmx:Anchor>
+                        </gmd:applicationProfile>
+                      </gmd:CI_OnlineResource>
+                    </gmd:onLine>
+                  <xsl:copy-of
+                    select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:offLine"
+                  />
+                </gmd:MD_DigitalTransferOptions>
+              </gmd:transferOptions>
+              <xsl:copy-of
+                select="gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions[position() > 1]"
+              />
+            </gmd:MD_Distribution>
+
+          </gmd:distributionInfo>
+        </xsl:otherwise>
+      </xsl:choose>
+
+
+      <xsl:copy-of
+        select="gmd:dataQualityInfo|
+                gmd:portrayalCatalogueInfo|
+                gmd:metadataConstraints|
+                gmd:applicationSchemaInfo|
+                gmd:metadataMaintenance|
+                gmd:series|
+                gmd:describes|
+                gmd:propertyType|
+                gmd:featureType|
+                gmd:featureAttribute"/>
+
+      <xsl:apply-templates select="*[namespace-uri()!='http://www.isotc211.org/2005/gmd' and
+                                     namespace-uri()!='http://www.isotc211.org/2005/srv']"/>
+
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Always remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/datasets-remove.xsl
+++ b/src/main/plugin/iso19139.rndt/process/datasets-remove.xsl
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Stylesheet used to remove a reference to a online resource.
+-->
+<xsl:stylesheet xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                version="2.0" exclude-result-prefixes="#all">
+
+  <xsl:param name="uuidref"/>
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <xsl:template
+    match="geonet:*|
+           srv:coupledResource[normalize-space(srv:SV_CoupledResource/srv:identifier/gco:CharacterString) = $uuidref]|
+           srv:operatesOn[@uuidref = $uuidref]|
+           srv:operatesOn[contains(@xlink.href,$uuidref)]"
+    priority="2"/>
+
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/linked-data-checker.xsl
+++ b/src/main/plugin/iso19139.rndt/process/linked-data-checker.xsl
@@ -1,4 +1,106 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
-  <xsl:import href="../../iso19139/process/linked-data-checker.xsl"/>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                xmlns:java="java:org.fao.geonet.util.XslUtil" version="2.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="process-utility.xsl"/>
+
+  <xsl:param name="linkUrl"/>
+
+  <!-- i18n information -->
+  <xsl:variable name="linked-data-checker-loc">
+    <msg id="a" xml:lang="eng"> returns an error (</msg>
+    <msg id="b" xml:lang="eng">). Run this task to remove it.</msg>
+    <msg id="a" xml:lang="fre"> a retourné une erreur (</msg>
+    <msg id="b" xml:lang="fre">). Si l'erreur persiste, corriger le lien manuellement ou exécuter
+      cette action pour le supprimer.
+    </msg>
+    <msg id="a" xml:lang="dut"> is niet bereikbaar of geeft een fout (</msg>
+    <msg id="b" xml:lang="dut">). Functie verwijdert de link.</msg>
+    <msg id="a" xml:lang="ita"> ritorna un errore (</msg>
+    <msg id="b" xml:lang="ita">). Lancia questo processo per eliminarlo.</msg>
+  </xsl:variable>
+
+  <xsl:template name="list-linked-data-checker">
+    <suggestion process="linked-data-checker"/>
+  </xsl:template>
+
+  <!-- Analyze the metadata record and return available suggestion
+    for that process -->
+  <xsl:template name="analyze-linked-data-checker">
+    <xsl:param name="root"/>
+
+    <!-- Check URL -->
+    <xsl:variable name="httpLinks"
+                  select="$root//*[starts-with(., 'http') and name(..) != 'geonet:info']"/>
+    <xsl:for-each-group select="$httpLinks" group-by=".">
+      <xsl:call-template name="checkUrl">
+        <xsl:with-param name="url" select="."/>
+      </xsl:call-template>
+    </xsl:for-each-group>
+  </xsl:template>
+
+  <xsl:template name="checkUrl">
+    <xsl:param name="url"/>
+    <xsl:param name="type"/>
+
+    <xsl:variable name="status" select="java:validateURL($url)"/>
+    <!--    <xsl:message>Check:<xsl:value-of select="."/>|<xsl:value-of select="$status"/></xsl:message>
+    -->
+    <xsl:if test="$status != true()">
+      <suggestion process="linked-data-checker" id="{generate-id()}" category="links" target="all">
+        <name xml:lang="en">
+          <xsl:value-of select="$type"/>
+          <xsl:value-of select="."/>
+          <xsl:value-of select="geonet:i18n($linked-data-checker-loc, 'a', $guiLang)"/>
+          <xsl:value-of select="$status"/>
+          <xsl:value-of select="geonet:i18n($linked-data-checker-loc, 'b', $guiLang)"/>
+        </name>
+        <operational>true</operational>
+        <params>{ "linkUrl":{"type":"string", "defaultValue":"<xsl:value-of
+          select="normalize-space($url)"/>"}
+          }
+        </params>
+      </suggestion>
+    </xsl:if>
+  </xsl:template>
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Always remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+  <!-- Remove the link. TODO : remove the parent ? -->
+  <xsl:template match="*[text()=$linkUrl]" priority="2"/>
+
+
 </xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/onlinesrc-add.xsl
+++ b/src/main/plugin/iso19139.rndt/process/onlinesrc-add.xsl
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Processing to insert or update an online resource element.
+Insert is made in first transferOptions found.
+-->
+<xsl:stylesheet xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:java="java:org.fao.geonet.util.XslUtil"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                version="2.0"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                exclude-result-prefixes="#all">
+
+  <!-- Main properties for the link.
+  Name and description may be multilingual eg. ENG#English name|FRE#Le français
+  Name and description may be a list of layer/feature type names and titles comma separated. -->
+  <xsl:param name="protocol" select="'OGC Web Map Service'"/>
+  <xsl:param name="url"/>
+  <xsl:param name="name"/>
+  <xsl:param name="desc"/>
+  <xsl:param name="function"/>
+  <xsl:param name="applicationProfile"/>
+
+  <!-- Add an optional uuidref attribute to the onLine element created. -->
+  <xsl:param name="uuidref"/>
+
+  <!-- In this case an external metadata is available under the
+  extra element and all online resource from this records are added
+  in this one. -->
+  <xsl:param name="extra_metadata_uuid"/>
+
+  <!-- Target element to update. The key is based on the concatenation
+  of URL+Protocol+Name -->
+  <xsl:param name="updateKey"/>
+
+  <xsl:variable name="thesaurusDir" select="java:getThesaurusDir()"/>
+
+  <xsl:variable name="appProfileLink">
+    <xsl:variable name="thesaurusFile" select="concat($thesaurusDir, '/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistSpatialDataServiceType-SpatialDataServiceType.rdf')"/>
+    <xsl:variable name="thesaurus" select="document($thesaurusFile)"/>
+    <xsl:variable name="concepts" select="$thesaurus/rdf:RDF/skos:Concept"/>
+      <xsl:if test="boolean($applicationProfile)">
+        <xsl:for-each select="$concepts">
+          <xsl:if test="skos:prefLabel=$applicationProfile">
+            <xsl:value-of select="@rdf:about"/>
+          </xsl:if>
+        </xsl:for-each>
+      </xsl:if>
+  </xsl:variable>
+
+  <xsl:variable name="descLink">
+    <xsl:variable name="thesaurusFile" select="concat($thesaurusDir, '/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistOnLineDescriptionCode-OnLineDescriptionCode.rdf')"/>
+    <xsl:variable name="thesaurus" select="document($thesaurusFile)"/>
+    <xsl:variable name="concepts" select="$thesaurus/rdf:RDF/skos:Concept"/>
+    <xsl:if test="boolean($desc)">
+      <xsl:for-each select="$concepts">
+        <xsl:if test="skos:prefLabel=$desc">
+          <xsl:value-of select="@rdf:about"/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:variable>
+
+  <xsl:variable name="protocolLink">
+    <xsl:variable name="thesaurusFile" select="concat($thesaurusDir, '/external/thesauri/theme/httpinspireeceuropaeumetadatacodelistProtocolValue-ProtocolValue.rdf')"/>
+    <xsl:variable name="thesaurus" select="document($thesaurusFile)"/>
+    <xsl:variable name="concepts" select="$thesaurus/rdf:RDF/skos:Concept"/>
+    <xsl:if test="boolean($protocol)">
+      <xsl:for-each select="$concepts">
+        <xsl:if test="skos:prefLabel=$protocol">
+          <xsl:value-of select="@rdf:about"/>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:variable>
+
+
+  <xsl:variable name="mainLang">
+    <xsl:value-of
+      select="(gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata'])/gmd:language/gmd:LanguageCode/@codeListValue"/>
+  </xsl:variable>
+
+  <xsl:template match="gmd:MD_Metadata|*[@gco:isoType='gmd:MD_Metadata']">
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates
+        select="gmd:fileIdentifier|
+                gmd:language|
+                gmd:characterSet|
+                gmd:parentIdentifier|
+                gmd:hierarchyLevel|
+                gmd:hierarchyLevelName|
+                gmd:contact|
+                gmd:dateStamp|
+                gmd:metadataStandardName|
+                gmd:metadataStandardVersion|
+                gmd:dataSetURI|
+                gmd:locale|
+                gmd:spatialRepresentationInfo|
+                gmd:referenceSystemInfo|
+                gmd:metadataExtensionInfo|
+                gmd:identificationInfo|
+                gmd:contentInfo"/>
+
+      <gmd:distributionInfo>
+        <gmd:MD_Distribution>
+          <xsl:apply-templates
+            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributionFormat"/>
+          <xsl:apply-templates
+            select="gmd:distributionInfo/gmd:MD_Distribution/gmd:distributor"/>
+          <gmd:transferOptions>
+            <gmd:MD_DigitalTransferOptions>
+              <xsl:apply-templates
+                select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:unitsOfDistribution"/>
+              <xsl:apply-templates
+                select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:transferSize"/>
+              <xsl:apply-templates
+                select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:onLine"/>
+
+
+              <xsl:if test="$updateKey = ''">
+                <xsl:call-template name="createOnlineSrc"/>
+              </xsl:if>
+
+              <xsl:apply-templates
+                select="gmd:distributionInfo/gmd:MD_Distribution/
+                          gmd:transferOptions[1]/gmd:MD_DigitalTransferOptions/gmd:offLine"/>
+            </gmd:MD_DigitalTransferOptions>
+          </gmd:transferOptions>
+
+
+          <xsl:apply-templates
+            select="gmd:distributionInfo/gmd:MD_Distribution/
+                      gmd:transferOptions[position() > 1]"/>
+
+        </gmd:MD_Distribution>
+      </gmd:distributionInfo>
+
+      <xsl:apply-templates
+        select="gmd:dataQualityInfo|
+                gmd:portrayalCatalogueInfo|
+                gmd:metadataConstraints|
+                gmd:applicationSchemaInfo|
+                gmd:metadataMaintenance|
+                gmd:series|
+                gmd:describes|
+                gmd:propertyType|
+                gmd:featureType|
+                gmd:featureAttribute"/>
+    </xsl:copy>
+  </xsl:template>
+
+
+  <!-- Updating the link matching the update key. -->
+  <xsl:template match="gmd:onLine[
+                        normalize-space($updateKey) = concat(
+                        gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
+                        gmd:CI_OnlineResource/gmd:protocol/gmx:Anchor,
+                        gmd:CI_OnlineResource/gmd:name/gco:CharacterString)
+                        ]">
+    <xsl:call-template name="createOnlineSrc"/>
+  </xsl:template>
+
+
+  <xsl:template name="createOnlineSrc">
+    <!-- Add all online source from the target metadata to the
+    current one -->
+    <xsl:if test="//extra">
+      <xsl:for-each select="//extra//gmd:onLine">
+        <gmd:onLine>
+          <xsl:if test="$extra_metadata_uuid">
+            <xsl:attribute name="uuidref" select="$extra_metadata_uuid"/>
+          </xsl:if>
+          <xsl:apply-templates select="*"/>
+        </gmd:onLine>
+      </xsl:for-each>
+    </xsl:if>
+
+    <xsl:variable name="separator" select="'\|'"/>
+    <xsl:variable name="useOnlyPTFreeText">
+      <xsl:value-of
+        select="count(//*[gmd:PT_FreeText and not(gco:CharacterString)]) > 0"/>
+    </xsl:variable>
+
+
+    <xsl:if test="$url">
+      <!-- In case the protocol is an OGC protocol
+      the name parameter may contains a list of layers
+      separated by comma.
+      In that case on one online element is added per
+      layer/featureType.
+      -->
+      <xsl:choose>
+        <xsl:when test="contains($protocol, 'OGC') and $name != ''">
+          <xsl:for-each select="tokenize($name, ',')">
+            <xsl:variable name="pos" select="position()"/>
+            <gmd:onLine>
+              <xsl:if test="$uuidref">
+                <xsl:attribute name="uuidref" select="$uuidref"/>
+              </xsl:if>
+              <gmd:CI_OnlineResource>
+                <gmd:linkage>
+                  <gmd:URL>
+                    <xsl:value-of select="$url"/>
+                  </gmd:URL>
+                </gmd:linkage>
+                <gmd:protocol>
+                  <gmx:Anchor xlink:href="{$protocolLink}">
+                    <xsl:value-of select="$protocol"/>
+                  </gmx:Anchor>
+                </gmd:protocol>
+                <gmd:applicationProfile>
+                   <gmx:Anchor xlink:href="{$appProfileLink}">
+                     <xsl:value-of select="$applicationProfile"/>
+                   </gmx:Anchor>
+                </gmd:applicationProfile>
+                <gmd:description>
+                  <gmx:Anchor xlink:href="{$descLink}">
+                    <xsl:value-of select="$desc"/>
+                  </gmx:Anchor>
+                </gmd:description>
+                <xsl:variable name="curName" select="."></xsl:variable>
+                <xsl:if test="$curName != ''">
+                  <gmd:name>
+                    <xsl:choose>
+
+                      <!--Multilingual-->
+                      <xsl:when test="contains($curName, '#')">
+                        <xsl:for-each select="tokenize($curName, $separator)">
+                          <xsl:variable name="nameLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="nameValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+                          <xsl:if
+                            test="$useOnlyPTFreeText = 'false' and $nameLang = $mainLang">
+                            <gco:CharacterString>
+                              <xsl:value-of select="$nameValue"/>
+                            </gco:CharacterString>
+                          </xsl:if>
+                        </xsl:for-each>
+
+                        <gmd:PT_FreeText>
+                          <xsl:for-each select="tokenize($curName, $separator)">
+                            <xsl:variable name="nameLang"
+                                          select="substring-before(., '#')"></xsl:variable>
+                            <xsl:variable name="nameValue"
+                                          select="substring-after(., '#')"></xsl:variable>
+
+                            <xsl:if
+                              test="$useOnlyPTFreeText = 'true' or $nameLang != $mainLang">
+                              <gmd:textGroup>
+                                <gmd:LocalisedCharacterString
+                                  locale="{concat('#', $nameLang)}">
+                                  <xsl:value-of select="$nameValue"/>
+                                </gmd:LocalisedCharacterString>
+                              </gmd:textGroup>
+                            </xsl:if>
+
+                          </xsl:for-each>
+                        </gmd:PT_FreeText>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <gco:CharacterString>
+                          <xsl:value-of select="$curName"/>
+                        </gco:CharacterString>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </gmd:name>
+                </xsl:if>
+              </gmd:CI_OnlineResource>
+            </gmd:onLine>
+          </xsl:for-each>
+        </xsl:when>
+        <xsl:otherwise>
+          <!-- ... the name is simply added in the newly
+          created online element. -->
+          <gmd:onLine>
+            <xsl:if test="$uuidref">
+              <xsl:attribute name="uuidref" select="$uuidref"/>
+            </xsl:if>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>
+                  <xsl:value-of select="$url"/>
+                </gmd:URL>
+              </gmd:linkage>
+
+              <xsl:if test="$protocol != ''">
+                <gmd:protocol>
+                  <gmx:Anchor xlink:href="{$protocolLink}">
+                    <xsl:value-of select="$protocol"/>
+                  </gmx:Anchor>
+                </gmd:protocol>
+              </xsl:if>
+
+              <xsl:if test="$applicationProfile != ''">
+                <gmd:applicationProfile>
+                  <gmx:Anchor xlink:href="{$appProfileLink}">
+                    <xsl:value-of select="$applicationProfile"/>
+                  </gmx:Anchor>
+                </gmd:applicationProfile>
+              </xsl:if>
+
+              <xsl:if test="$name != ''">
+                <gmd:name>
+                  <xsl:choose>
+                    <!--Multilingual-->
+                    <xsl:when test="contains($name, '#')">
+                      <xsl:for-each select="tokenize($name, $separator)">
+                        <xsl:variable name="nameLang"
+                                      select="substring-before(., '#')"></xsl:variable>
+                        <xsl:variable name="nameValue"
+                                      select="substring-after(., '#')"></xsl:variable>
+
+                        <xsl:if
+                          test="$useOnlyPTFreeText = 'false' and $nameLang = $mainLang">
+                          <gco:CharacterString>
+                            <xsl:value-of select="$nameValue"/>
+                          </gco:CharacterString>
+                        </xsl:if>
+                      </xsl:for-each>
+
+                      <gmd:PT_FreeText>
+                        <xsl:for-each select="tokenize($name, $separator)">
+                          <xsl:variable name="nameLang"
+                                        select="substring-before(., '#')"></xsl:variable>
+                          <xsl:variable name="nameValue"
+                                        select="substring-after(., '#')"></xsl:variable>
+
+                          <xsl:if
+                            test="$useOnlyPTFreeText = 'true' or $nameLang != $mainLang">
+                            <gmd:textGroup>
+                              <gmd:LocalisedCharacterString
+                                locale="{concat('#', $nameLang)}">
+                                <xsl:value-of select="$nameValue"/>
+                              </gmd:LocalisedCharacterString>
+                            </gmd:textGroup>
+                          </xsl:if>
+
+                        </xsl:for-each>
+                      </gmd:PT_FreeText>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <gco:CharacterString>
+                        <xsl:value-of select="$name"/>
+                      </gco:CharacterString>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </gmd:name>
+              </xsl:if>
+
+              <xsl:if test="$desc != ''">
+                <gmd:description>
+                  <gmx:Anchor xlink:href="{$descLink}">
+                    <xsl:value-of select="$desc"/>
+                  </gmx:Anchor>
+                </gmd:description>
+              </xsl:if>
+
+              <xsl:if test="$function != ''">
+                <gmd:function>
+                  <gmd:CI_OnLineFunctionCode
+                    codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_OnLineFunctionCode"
+                    codeListValue="{$function}"/>
+                </gmd:function>
+              </xsl:if>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template match="extra" priority="2"/>
+
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/onlinesrc-remove.xsl
+++ b/src/main/plugin/iso19139.rndt/process/onlinesrc-remove.xsl
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Stylesheet used to remove a reference to a online resource.
+-->
+<xsl:stylesheet xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0">
+
+  <xsl:param name="url"/>
+  <xsl:param name="name"/>
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template
+    match="geonet:*|gmd:onLine[normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = $name]"
+    priority="2"/>
+  <xsl:template
+    match="geonet:*|gmd:onLine[normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and count(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup[gmd:LocalisedCharacterString = $name]) > 0]"
+    priority="2"/>
+  <xsl:template
+    match="geonet:*|gmd:onLine[normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:protocol/gmx:Anchor/@xlink:hreaf) = 'download']"
+    priority="2"/>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/parent-remove.xsl
+++ b/src/main/plugin/iso19139.rndt/process/parent-remove.xsl
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Stylesheet used to remove a reference to a parent record.
+-->
+<xsl:stylesheet xmlns:geonet="http://www.fao.org/geonetwork" xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                version="2.0">
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*|gmd:issueIdentification" priority="2"/>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/service-add.xsl
+++ b/src/main/plugin/iso19139.rndt/process/service-add.xsl
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Stylesheet used to update metadata for a service and
+attached it to the metadata for data.
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+  <xsl:include href="dataset-add.xsl"/>
+</xsl:stylesheet>

--- a/src/main/plugin/iso19139.rndt/process/services-remove.xsl
+++ b/src/main/plugin/iso19139.rndt/process/services-remove.xsl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<!--
+Stylesheet used to update metadata for a service and
+detach a dataset metadata
+-->
+<xsl:stylesheet xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:srv="http://www.isotc211.org/2005/srv"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:geonet="http://www.fao.org/geonetwork"
+                version="2.0"
+>
+
+  <xsl:param name="uuidref"/>
+
+  <!-- Detach -->
+  <xsl:template match="srv:operatesOn[@uuidref=$uuidref]" priority="2"/>
+  <xsl:template
+    match="srv:coupledResource[srv:SV_CoupledResource/srv:identifier/gco:CharacterString=$uuidref]"
+    priority="2"/>
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2"/>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- Aggiunti da iso19139 gli xsl necessari per la funzione di link tra risorsa e servizio;
- Modificati gli xsl in accordo con la definizione dei campi dell'online resource per RNDT (gmx:Anchor invece di gco:CharacterString)

- Rimozione di parti di xsl non necessarie per rndt rispetto a iso19139
